### PR TITLE
Typings: add number type for set and push methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module 'quick.db' {
      * @param {options} [input={ target: null }] Any options to be added to the request.
      * @returns {data} the updated data.
      */
-    function set(key: string, value: string|object|Array<any>, ops?: object): any;
+    function set(key: string, value: string|object|number|Array<any>, ops?: object): any;
 
     /**
      * This function adds a number to a key in the database. (If no existing number, it will add to 0)
@@ -45,7 +45,7 @@ declare module 'quick.db' {
      * @param {options} [input={ target: null }] Any options to be added to the request.
      * @returns {data} the updated data.
      */
-    function push(key: string, value: string|object|Array<any>): Array<any>;
+    function push(key: string, value: string|object|number|Array<any>): Array<any>;
 
     /**
      * This function returns a boolean indicating whether an element with the specified key exists or not.


### PR DESCRIPTION
I think `number` should be a valid type for the `value` parameter of the `set` and `push` methods. I'm getting an error when trying to do the following:
![Capture d’écran 2020-05-20 à 21 26 37](https://user-images.githubusercontent.com/42497995/82488724-aaf8b800-9ae0-11ea-9224-fad76118fa86.png)
And the following code works well (using vanilla js):
```js
const quickdb = require("quick.db");
quickdb.set("key", 3);
console.log(typeof quickdb.get("key")); // number
```