### PR TITLE
Fixes #229 normal keys

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -62,7 +62,7 @@ describe("QuickDB", () => {
             }
         }
 
-        driverMock.data = [];
+        driverMock.data = {};
     });
 
     describe("Test with no data", () => {
@@ -135,6 +135,18 @@ describe("QuickDB", () => {
             await expect(db.get("test.sword")).resolves.toEqual("hi");
             expect(driverMock.getRowByKey).toHaveBeenCalledWith("json", "test");
             expect(driverMock.getRowByKey).toHaveBeenCalledTimes(1);
+        });
+
+        test("set_get_normal_keys", async () => {
+            db.useNormalKeys(true);
+            await expect(db.set("test.sword", "hi")).resolves.toEqual("hi");
+            expect(driverMock.setRowByKey).toHaveBeenCalledTimes(1);
+            expect(driverMock.getRowByKey).toHaveBeenCalledTimes(1);
+            console.log(driverMock.data);
+            expect(driverMock.data).toHaveProperty(["test.sword"]);
+            expect(driverMock.data["test.sword"]).toEqual("hi");
+
+            db.useNormalKeys(false);
         });
 
         test("delete_bad_key", async () => {


### PR DESCRIPTION
Adding of normal keys instead of dot notation.
It can be toggle on or off with the new method `useNormalKeys`
Like it can also be passed in the QuickDB option when it's initialized